### PR TITLE
Initial attempt to allow logging to be turned off

### DIFF
--- a/src/main/java/com/tomitribe/snitch/agent/Agent.java
+++ b/src/main/java/com/tomitribe/snitch/agent/Agent.java
@@ -36,7 +36,7 @@ import java.util.Properties;
 public class Agent {
 
     private static Instrumentation instrumentation;
-    private static boolean logEnabled;
+    private static boolean logEnabled = true;
 
     private Agent() {
         // no-op
@@ -111,6 +111,7 @@ public class Agent {
             }
 
             logEnabled = Boolean.parseBoolean(properties.getProperty("snitch.logging", "true"));
+            properties.remove("snitch.logging");
 
             instrumentation.addTransformer(new Tracker(Enhancer.create(properties), instrumentation));
             out("Tracker installed.  Configuration files '%s'", Join.join(",", new Join.NameCallback<File>() {

--- a/src/main/java/com/tomitribe/snitch/agent/Agent.java
+++ b/src/main/java/com/tomitribe/snitch/agent/Agent.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 public class Agent {
 
     private static Instrumentation instrumentation;
+    private static boolean logEnabled;
 
     private Agent() {
         // no-op
@@ -109,6 +110,8 @@ public class Agent {
                 IO.readProperties(file, properties);
             }
 
+            logEnabled = Boolean.parseBoolean(properties.getProperty("snitch.logging", "true"));
+
             instrumentation.addTransformer(new Tracker(Enhancer.create(properties), instrumentation));
             out("Tracker installed.  Configuration files '%s'", Join.join(",", new Join.NameCallback<File>() {
                 @Override
@@ -154,5 +157,9 @@ public class Agent {
             }
         }
 
+    }
+
+    public static boolean isLogEnabled() {
+        return logEnabled;
     }
 }

--- a/src/main/java/com/tomitribe/snitch/track/Log.java
+++ b/src/main/java/com/tomitribe/snitch/track/Log.java
@@ -16,6 +16,8 @@
  */
 package com.tomitribe.snitch.track;
 
+import com.tomitribe.snitch.agent.Agent;
+
 /**
  * @version $Revision$ $Date$
  */
@@ -26,11 +28,13 @@ public class Log {
     }
 
     public static void log(final String format, final Object... details) {
+        if (!Agent.isLogEnabled()) return;
         final String message = String.format(format, details);
         System.out.printf("%tF %<tT - SNITCH: %s%n", System.currentTimeMillis(), message);
     }
 
     public static void err(final String format, final Object... details) {
+        if (!Agent.isLogEnabled()) return;
         final String message = String.format(format, details);
         System.err.printf("%tF %<tT - SNITCH: %s%n", System.currentTimeMillis(), message);
     }

--- a/src/main/java/com/tomitribe/snitch/track/Tracker.java
+++ b/src/main/java/com/tomitribe/snitch/track/Tracker.java
@@ -17,6 +17,7 @@
 
 package com.tomitribe.snitch.track;
 
+import com.tomitribe.snitch.agent.Agent;
 import com.tomitribe.snitch.util.Join;
 
 import java.util.Collection;
@@ -85,6 +86,7 @@ public class Tracker {
     }
 
     private void report() {
+        if (! Agent.isLogEnabled()) return;
         if (stats.size() > 0) {
             log.info("TRACK: " + Join.join(" - ", stats.values()));
         }


### PR DESCRIPTION
If you are using the Snitch tracker within another app to collect timings, it may not be useful (and indeed can be impactful on performance) to log every timing. This code allows snitch.logging=false to be set in snitch.properties to turn logging off.