### PR TITLE
Check the the insert method is weavable, and that the class file is actually changed

### DIFF
--- a/src/main/java/com/tomitribe/snitch/listen/InsertStaticCallVisitor.java
+++ b/src/main/java/com/tomitribe/snitch/listen/InsertStaticCallVisitor.java
@@ -31,6 +31,8 @@ public class InsertStaticCallVisitor extends ClassVisitor implements Opcodes {
     private final Method find;
     private final Method insert;
 
+    private int found = 0;
+
     public InsertStaticCallVisitor(final ClassWriter classVisitor, final Method find, final Method insert) {
         super(ASM.VERSION, classVisitor);
         this.find = find;
@@ -53,6 +55,7 @@ public class InsertStaticCallVisitor extends ClassVisitor implements Opcodes {
             return methodVisitor;
         }
 
+        found++;
         return new MethodVisitor(ASM.VERSION, methodVisitor) {
             @Override
             public void visitCode() {
@@ -61,5 +64,9 @@ public class InsertStaticCallVisitor extends ClassVisitor implements Opcodes {
                 super.visitCode();
             }
         };
+    }
+
+    public int getFound() {
+        return found;
     }
 }

--- a/src/main/java/com/tomitribe/snitch/listen/StaticNoArgCallback.java
+++ b/src/main/java/com/tomitribe/snitch/listen/StaticNoArgCallback.java
@@ -14,6 +14,7 @@ import com.tomitribe.snitch.track.Bytecode;
 import com.tomitribe.snitch.util.Join;
 import org.objectweb.asm.ClassWriter;
 
+import java.lang.reflect.Modifier;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -90,6 +91,20 @@ public class StaticNoArgCallback implements Function<byte[], byte[]> {
         }
 
         public Builder insert(final java.lang.reflect.Method method) {
+            // As this is a reflection method, we can check that it is suitable for weaving
+
+            if (! Modifier.isStatic(method.getModifiers())) {
+                throw new IllegalArgumentException("Insert method must be static.");
+            }
+
+            if (Modifier.isPrivate(method.getModifiers())) {
+                throw new IllegalArgumentException("Insert method must not be private");
+            }
+
+            if (method.getParameters().length > 0) {
+                throw new IllegalArgumentException("Insert method must have no arguments.");
+            }
+
             this.insert = new Method(method);
             return this;
         }

--- a/src/main/java/com/tomitribe/snitch/listen/StaticNoArgCallback.java
+++ b/src/main/java/com/tomitribe/snitch/listen/StaticNoArgCallback.java
@@ -38,8 +38,15 @@ public class StaticNoArgCallback implements Function<byte[], byte[]> {
     @Override
     public byte[] apply(final byte[] bytes) {
         final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-        final ClassVisitor classAdapter = new InsertStaticCallVisitor(cw, find, insert);
+        final InsertStaticCallVisitor classAdapter = new InsertStaticCallVisitor(cw, find, insert);
         Bytecode.read(bytes, classAdapter);
+
+        if (classAdapter.getFound() == 0) {
+            throw new IllegalArgumentException(find.toString() + " method was not found");
+        }
+
+        System.out.println("Replace " + classAdapter.getFound() + " instances of " + find.toString());
+
         return cw.toByteArray();
     }
 

--- a/src/test/java/com/tomitribe/snitch/listen/StaticCallTest.java
+++ b/src/test/java/com/tomitribe/snitch/listen/StaticCallTest.java
@@ -64,7 +64,7 @@ public class StaticCallTest extends Assert {
         assertEnhancement(enhancer, OrangeBefore.class, OrangeAfter.class);
     }
 
-    private static void assertEnhancement(final Function<byte[], byte[]> enhancer, final Class<?> beforeClass, final Class<?> afterClass) throws IOException {
+    public static void assertEnhancement(final Function<byte[], byte[]> enhancer, final Class<?> beforeClass, final Class<?> afterClass) throws IOException {
         final byte[] bytes = Bytecode.readClassFile(beforeClass);
         final byte[] actualBytes = enhancer.apply(bytes);
         final byte[] expectedBytes = Bytecode.readClassFile(afterClass);

--- a/src/test/java/com/tomitribe/snitch/listen/StaticNoArgCallbackTest.java
+++ b/src/test/java/com/tomitribe/snitch/listen/StaticNoArgCallbackTest.java
@@ -9,6 +9,7 @@
  */
 package com.tomitribe.snitch.listen;
 
+import com.tomitribe.snitch.listen.gen.Interceptor;
 import com.tomitribe.snitch.listen.gen.ProcessorAfter;
 import com.tomitribe.snitch.listen.gen.ProcessorBefore;
 import com.tomitribe.snitch.track.Bytecode;
@@ -50,7 +51,7 @@ public class StaticNoArgCallbackTest {
     }
 
     @Test
-    public void testShouldFailToWeaveAsMethodWithArguments() throws Exception {
+    public void testShouldFailToWeaveAMethodWithArguments() throws Exception {
         try {
 
             final Function<byte[], byte[]> transformer = StaticNoArgCallback.builder()
@@ -67,5 +68,41 @@ public class StaticNoArgCallbackTest {
             Assert.assertEquals("Insert method must have no arguments.  Found: Ljava/lang/String;", e.getMessage());
         }
     }
+
+    @Test
+    public void testShouldFailToWeaveANonStaticMethodWithoutArguments() throws Exception {
+        try {
+            final Function<byte[], byte[]> transformer = StaticNoArgCallback.builder()
+                    .find("void com.tomitribe.snitch.listen.gen.ProcessorBefore.foo()")
+                    .insert(Interceptor.class.getDeclaredMethod("doWork"))
+                    .check()
+                    .build();
+
+            final byte[] bytes = Bytecode.readClassFile(ProcessorBefore.class);
+            final byte[] woven = transformer.apply(bytes);
+
+            Assert.fail("Expected exception not thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Insert method must be static.", e.getMessage());
+        }
+    }
+    @Test
+    public void testShouldFailToWeaveANonStaticMethodWithArguments() throws Exception {
+        try {
+            final Function<byte[], byte[]> transformer = StaticNoArgCallback.builder()
+                    .find("void com.tomitribe.snitch.listen.gen.ProcessorBefore.foo()")
+                    .insert(Interceptor.class.getDeclaredMethod("doWork", String.class))
+                    .check()
+                    .build();
+
+            final byte[] bytes = Bytecode.readClassFile(ProcessorBefore.class);
+            final byte[] woven = transformer.apply(bytes);
+
+            Assert.fail("Expected exception not thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Insert method must be static.", e.getMessage());
+        }
+    }
+
 
 }

--- a/src/test/java/com/tomitribe/snitch/listen/StaticNoArgCallbackTest.java
+++ b/src/test/java/com/tomitribe/snitch/listen/StaticNoArgCallbackTest.java
@@ -1,0 +1,71 @@
+/*
+ * Tomitribe Confidential
+ *
+ * Copyright Tomitribe Corporation. 2023
+ *
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
+ * U.S. Copyright Office.
+ */
+package com.tomitribe.snitch.listen;
+
+import com.tomitribe.snitch.listen.gen.ProcessorAfter;
+import com.tomitribe.snitch.listen.gen.ProcessorBefore;
+import com.tomitribe.snitch.track.Bytecode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+public class StaticNoArgCallbackTest {
+
+    @Test
+    public void testWeaveStaticNoArgMethodIntoStartOfAnInstanceMethod() throws Exception {
+        final Function<byte[], byte[]> transformer = StaticNoArgCallback.builder()
+                .find("void com.tomitribe.snitch.listen.gen.ProcessorBefore.doWork()")
+                .insert("void com.tomitribe.snitch.listen.gen.Interceptor.intercept()")
+                .check()
+                .build();
+
+        StaticCallTest.assertEnhancement(transformer, ProcessorBefore.class, ProcessorAfter.class);
+    }
+
+    @Test
+    public void testShouldFailToWeaveAsMethodNotFound() throws Exception {
+        try {
+
+            final Function<byte[], byte[]> transformer = StaticNoArgCallback.builder()
+                    .find("void com.tomitribe.snitch.listen.gen.ProcessorBefore.foo()")
+                    .insert("void com.tomitribe.snitch.listen.gen.Interceptor.intercept()")
+                    .check()
+                    .build();
+
+            final byte[] bytes = Bytecode.readClassFile(ProcessorBefore.class);
+            final byte[] woven = transformer.apply(bytes);
+
+            Assert.fail("Expected exception not thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("com.tomitribe.snitch.listen.gen.ProcessorBefore.foo() method was not found", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testShouldFailToWeaveAsMethodWithArguments() throws Exception {
+        try {
+
+            final Function<byte[], byte[]> transformer = StaticNoArgCallback.builder()
+                    .find("void com.tomitribe.snitch.listen.gen.ProcessorBefore.foo()")
+                    .insert("void com.tomitribe.snitch.listen.gen.Interceptor.log(java.lang.String)")
+                    .check()
+                    .build();
+
+            final byte[] bytes = Bytecode.readClassFile(ProcessorBefore.class);
+            final byte[] woven = transformer.apply(bytes);
+
+            Assert.fail("Expected exception not thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Insert method must have no arguments.  Found: Ljava/lang/String;", e.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/com/tomitribe/snitch/listen/gen/Interceptor.java
+++ b/src/test/java/com/tomitribe/snitch/listen/gen/Interceptor.java
@@ -1,0 +1,22 @@
+/*
+ * Tomitribe Confidential
+ *
+ * Copyright Tomitribe Corporation. 2023
+ *
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
+ * U.S. Copyright Office.
+ */
+package com.tomitribe.snitch.listen.gen;
+
+public class Interceptor {
+
+    public static void intercept() {
+        System.out.println("Intercepting");
+    }
+
+    public static void log(final String toLog) {
+        System.out.println(toLog);
+    }
+
+}

--- a/src/test/java/com/tomitribe/snitch/listen/gen/Interceptor.java
+++ b/src/test/java/com/tomitribe/snitch/listen/gen/Interceptor.java
@@ -19,4 +19,12 @@ public class Interceptor {
         System.out.println(toLog);
     }
 
+    public void doWork() {
+        System.out.println("Doing work");
+    }
+
+    public void doWork(final String toLog) {
+        System.out.println("Doing work: " + toLog);
+    }
+
 }

--- a/src/test/java/com/tomitribe/snitch/listen/gen/ProcessorAfter.java
+++ b/src/test/java/com/tomitribe/snitch/listen/gen/ProcessorAfter.java
@@ -1,0 +1,23 @@
+/*
+ * Tomitribe Confidential
+ *
+ * Copyright Tomitribe Corporation. 2023
+ *
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
+ * U.S. Copyright Office.
+ */
+package com.tomitribe.snitch.listen.gen;
+
+public class ProcessorAfter {
+
+    public void doWork() {
+        Interceptor.intercept();
+        System.out.println("Doing work");
+    }
+
+    public static void main(String[] args) {
+        new ProcessorAfter().doWork();
+    }
+
+}

--- a/src/test/java/com/tomitribe/snitch/listen/gen/ProcessorBefore.java
+++ b/src/test/java/com/tomitribe/snitch/listen/gen/ProcessorBefore.java
@@ -1,0 +1,22 @@
+/*
+ * Tomitribe Confidential
+ *
+ * Copyright Tomitribe Corporation. 2023
+ *
+ * The source code for this program is not published or otherwise divested
+ * of its trade secrets, irrespective of what has been deposited with the
+ * U.S. Copyright Office.
+ */
+package com.tomitribe.snitch.listen.gen;
+
+public class ProcessorBefore {
+
+    public void doWork() {
+        System.out.println("Doing work");
+    }
+
+    public static void main(String[] args) {
+        new ProcessorBefore().doWork();
+    }
+
+}


### PR DESCRIPTION
This PR does the following:

Introduces a `check()` parameter to the `StaticNoArgCallback` class. When set, this will check that the apply method actually finds the `find()` method and weaves it. The `insert()` method is not reflection based, and could represent a class/method that is not present in the classloader and cannot be inspected via reflection to ensure it is static and has no arguments. However, this PR does introduce a check when `insert()` is call with a java.lang.reflect.Method to ensure the method's suitability and throw an `IllegalArgumentException` if it is not.